### PR TITLE
fix(Slack): send markdown answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@slack/bolt": "^3.17.1",
         "@stripe/stripe-js": "^3.3.0",
         "@tanstack/react-table": "^8.15.0",
+        "@tryfabric/mack": "^1.2.1",
         "@types/mdx": "^2.0.13",
         "bullmq": "^5.4.6",
         "class-variance-authority": "^0.7.0",
@@ -4625,6 +4626,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tryfabric/mack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@tryfabric/mack/-/mack-1.2.1.tgz",
+      "integrity": "sha512-qQKj3l4x/7fWPHyk3zO3hPK2NUTH8AINJnVbdBYforWpm+6RDzp22gFIE66BJd2z7EFmt7F9aUOyZTKwmxiXrA==",
+      "dependencies": {
+        "@slack/types": "^2.1.0",
+        "fast-xml-parser": "^4.0.6",
+        "marked": "^4.0.12"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -8830,6 +8841,27 @@
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastest-stable-stringify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
@@ -11922,6 +11954,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -18622,6 +18665,11 @@
         "node": ">=12.*"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/style-to-object": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.4.tgz",
@@ -23159,6 +23207,16 @@
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.14.0.tgz",
       "integrity": "sha512-wDhpKJahGHWhmRt4RxtV3pES63CoeadljGWS/xeS9OJr1HBl2NB+OO44ht3sxDH5j5TRDAbQzC0NvSlsUfn7lQ=="
     },
+    "@tryfabric/mack": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@tryfabric/mack/-/mack-1.2.1.tgz",
+      "integrity": "sha512-qQKj3l4x/7fWPHyk3zO3hPK2NUTH8AINJnVbdBYforWpm+6RDzp22gFIE66BJd2z7EFmt7F9aUOyZTKwmxiXrA==",
+      "requires": {
+        "@slack/types": "^2.1.0",
+        "fast-xml-parser": "^4.0.6",
+        "marked": "^4.0.12"
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -26398,6 +26456,14 @@
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
+    "fast-xml-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fastest-stable-stringify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
@@ -28495,6 +28561,11 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
+    },
+    "marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "mdast-util-definitions": {
       "version": "5.1.2",
@@ -32987,6 +33058,11 @@
         "@types/node": ">=8.1.0",
         "qs": "^6.11.0"
       }
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "style-to-object": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@slack/bolt": "^3.17.1",
     "@stripe/stripe-js": "^3.3.0",
     "@tanstack/react-table": "^8.15.0",
+    "@tryfabric/mack": "^1.2.1",
     "@types/mdx": "^2.0.13",
     "bullmq": "^5.4.6",
     "class-variance-authority": "^0.7.0",

--- a/src/queue/handlers/handle-reply-slack-mention.ts
+++ b/src/queue/handlers/handle-reply-slack-mention.ts
@@ -3,6 +3,7 @@ import { ReplySlackMention } from '@/queue/jobs'
 import { findOrgWithSlackTeamId } from '@/lib/organization/get-org-with-slack-team-id'
 import { getAnswer } from '@/lib/ai/chat/get-answer'
 import { getTextReplies } from '@/lib/slack/get-text-replies'
+import { markdownToBlocks } from '@tryfabric/mack'
 
 export async function handleReplySlackMention(job: ReplySlackMention) {
   const { channel_id, target_message_ts, text, team_id, thread_ts } = job.data
@@ -37,7 +38,7 @@ export async function handleReplySlackMention(job: ReplySlackMention) {
     await slackClient.post('chat.postMessage', {
       channel: channel_id,
       thread_ts: target_message_ts,
-      text: answer,
+      blocks: await markdownToBlocks(answer),
     })
 
     return
@@ -77,6 +78,6 @@ export async function handleReplySlackMention(job: ReplySlackMention) {
   await slackClient.post('chat.postMessage', {
     channel: channel_id,
     thread_ts: target_message_ts,
-    text: answer,
+    blocks: await markdownToBlocks(answer),
   })
 }

--- a/src/queue/handlers/handle-reply-slack-thread.ts
+++ b/src/queue/handlers/handle-reply-slack-thread.ts
@@ -3,6 +3,7 @@ import { ReplySlackThread } from '@/queue/jobs'
 import { findOrgWithSlackTeamId } from '@/lib/organization/get-org-with-slack-team-id'
 import { getTextReplies } from '@/lib/slack/get-text-replies'
 import { getAnswer } from '@/lib/ai/chat/get-answer'
+import { markdownToBlocks } from '@tryfabric/mack'
 
 export async function handleReplySlackThread(job: ReplySlackThread) {
   const {
@@ -53,6 +54,6 @@ export async function handleReplySlackThread(job: ReplySlackThread) {
   await slackClient.post('chat.postMessage', {
     channel: channel_id,
     thread_ts: target_message_ts,
-    text: answer,
+    blocks: await markdownToBlocks(answer),
   })
 }


### PR DESCRIPTION
closes #36 

- This pull request addresses the issue where markdown messages are being sent as raw text without proper formatting.
- The goal is to ensure that markdown answers are correctly formatted when sent through Slack.