### PR TITLE
fix(Trello): missing list in edit event

### DIFF
--- a/src/app/api/trello/webhook/route.ts
+++ b/src/app/api/trello/webhook/route.ts
@@ -29,7 +29,6 @@ export const POST = async (request: NextRequest) => {
       await dispatch('create_homie_task_from_trello_task', {
         board: action.data.board,
         card: action.data.card,
-        list: action.data.list,
       })
 
       break
@@ -37,7 +36,6 @@ export const POST = async (request: NextRequest) => {
       await dispatch('update_homie_task_from_trello_task', {
         board: action.data.board,
         card: action.data.card,
-        list: action.data.list,
         updated_fields: Object.keys(action.data.old) as any, // untyped anyway
       })
 

--- a/src/queue/handlers/handle-create-homie-task-from-trello-task.ts
+++ b/src/queue/handlers/handle-create-homie-task-from-trello-task.ts
@@ -6,7 +6,7 @@ import { taskStatus } from '@/lib/tasks'
 export async function handleCreateHomieTaskFromTrelloTask(
   job: CreateHomieTaskFromTrelloTask,
 ) {
-  const { board, card, list } = job.data
+  const { board, card } = job.data
 
   const trelloWorkspace = await dbClient
     .selectFrom('trello.workspace')
@@ -37,7 +37,9 @@ export async function handleCreateHomieTaskFromTrelloTask(
     description: '',
   })
 
-  const isDone = list.id === trelloWorkspace.ext_trello_done_task_list_id
+  const isDone = card.idList
+    ? card.idList === trelloWorkspace.ext_trello_done_task_list_id
+    : false
 
   await dbClient
     .insertInto('homie.task')

--- a/src/queue/handlers/handle-update-homie-task-from-trello-task.ts
+++ b/src/queue/handlers/handle-update-homie-task-from-trello-task.ts
@@ -8,7 +8,7 @@ import { taskStatus } from '@/lib/tasks'
 export async function handleUpdateHomieTaskFromTrelloTask(
   job: UpdateHomieTaskFromTrelloTask,
 ) {
-  const { board, card, list, updated_fields } = job.data
+  const { board, card, updated_fields } = job.data
 
   const trelloWorkspace = await dbClient
     .selectFrom('trello.workspace')
@@ -44,7 +44,6 @@ export async function handleUpdateHomieTaskFromTrelloTask(
     await dispatch('create_homie_task_from_trello_task', {
       board,
       card,
-      list,
     })
     return
   }

--- a/src/queue/jobs.ts
+++ b/src/queue/jobs.ts
@@ -189,11 +189,9 @@ export type CreateHomieTaskFromTrelloTask = BullMQJob<
     board: {
       id: string
     }
-    list: {
-      id: string
-    }
     card: {
       id: string
+      idList?: string
       shortLink: string
       name: string
     }
@@ -207,17 +205,14 @@ export type UpdateHomieTaskFromTrelloTask = BullMQJob<
     board: {
       id: string
     }
-    list: {
-      id: string
-    }
     card: {
       id: string
+      idList?: string
       shortLink: string
       name: string
       desc?: string
       due?: string
       closed?: boolean
-      idList?: string
     }
     updated_fields: Array<'name' | 'desc' | 'due'>
   },


### PR DESCRIPTION
Fixes job errors where `list` is undefined in Trello webhooks for card edit.