### PR TITLE
fix(PR Summaries): fix pr day delay

### DIFF
--- a/src/lib/reporting/get-pull-request-cut-off-date.ts
+++ b/src/lib/reporting/get-pull-request-cut-off-date.ts
@@ -1,4 +1,4 @@
-import { subDays } from 'date-fns'
+import { subHours } from 'date-fns'
 
 interface GetPullRequestCutoffDateParams {
   organization: {
@@ -15,8 +15,8 @@ export function getPullRequestCutoffDate(
   const { send_pull_request_summaries_interval } = organization
 
   if (send_pull_request_summaries_interval === 'daily') {
-    return subDays(new Date(), 1)
+    return subHours(new Date(), 24)
   }
 
-  return subDays(new Date(), 7)
+  return subHours(new Date(), 168) // 24 * 7 (Days)
 }


### PR DESCRIPTION
- Fixed the delay in generating pull request summaries by adjusting the calculation method to subtract hours instead of days.
- Resolved the issue by changing the import from 'subDays' to 'subHours' from the date-fns library.