### PR TITLE
fix(PRs): import via separate jobs

### DIFF
--- a/src/app/api/gitlab/projects/[project_id]/route.ts
+++ b/src/app/api/gitlab/projects/[project_id]/route.ts
@@ -53,6 +53,7 @@ export const PATCH = createRoute(
         'gitlab.app_user.gitlab_webhook_secret',
         'trello.workspace.trello_access_token',
         'asana_access_token',
+        'homie.organization.has_unlimited_usage',
       ])
       .executeTakeFirst()
 

--- a/src/queue/handlers/handle-import-gitlab-merge-requests.ts
+++ b/src/queue/handlers/handle-import-gitlab-merge-requests.ts
@@ -1,6 +1,6 @@
 import { ImportGitlabMergeRequests } from '@/queue/jobs'
 import { createGitlabClient } from '@/lib/gitlab/create-gitlab-client'
-import { saveMergedMergeRequest } from '@/lib/gitlab/save-merged-merge-request'
+import { dispatch } from '@/queue/default-queue'
 
 export async function handleImportGitlabMergeRequests(
   job: ImportGitlabMergeRequests,
@@ -25,10 +25,17 @@ export async function handleImportGitlabMergeRequests(
   })
 
   for (const mergeRequest of mergeRequests) {
-    await saveMergedMergeRequest({
-      mergeRequest,
+    await dispatch('save_merged_merge_request', {
+      merge_request: {
+        created_at: mergeRequest.created_at,
+        id: mergeRequest.id,
+        iid: mergeRequest.iid,
+        title: mergeRequest.title,
+        target_project_id: mergeRequest.target_project_id,
+        author_id: mergeRequest.author.id,
+        description: mergeRequest.description,
+      },
       organization,
-      project,
     })
   }
 }

--- a/src/queue/handlers/handle-import-pull-requests.ts
+++ b/src/queue/handlers/handle-import-pull-requests.ts
@@ -1,10 +1,10 @@
 import { dbClient } from '@/database/client'
 import { createGithubClient } from '@/lib/github/create-github-client'
-import { saveMergedPullRequest } from '@/lib/github/save-merged-pull-request'
 import { getOrganizationLogData } from '@/lib/organization/get-organization-log-data'
 import { getPullRequestLogData } from '@/lib/github/get-pull-request-log-data'
 import { logger } from '@/lib/log/logger'
 import { ImportPullRequests } from '@/queue/jobs'
+import { dispatch } from '@/queue/default-queue'
 
 export async function handleImportPullRequests(job: ImportPullRequests) {
   logger.debug('Start pull request import', {
@@ -90,8 +90,8 @@ export async function handleImportPullRequests(job: ImportPullRequests) {
         continue
       }
 
-      await saveMergedPullRequest({
-        pullRequest: {
+      await dispatch('save_merged_pull_request', {
+        pull_request: {
           user: {
             id: pullRequest.user.id,
             login: pullRequest.user.login,
@@ -108,7 +108,9 @@ export async function handleImportPullRequests(job: ImportPullRequests) {
             ref: pullRequest.base.ref,
           },
         },
-        organization,
+        installation: {
+          id: github_organization.ext_gh_install_id,
+        },
       })
     }
   }

--- a/src/queue/jobs.ts
+++ b/src/queue/jobs.ts
@@ -101,8 +101,32 @@ export type SaveOpenedPullRequest = BullMQJob<
 
 export type SaveMergedPullRequest = BullMQJob<
   {
-    pull_request: PullRequest
-    installation: InstallationLite | undefined
+    pull_request: {
+      user: {
+        id: number
+        login: string
+      }
+      merged_at: string | null
+      body: string | null
+      id: number
+      title: string
+      number: number
+      created_at: string
+      base: {
+        repo: {
+          id: number
+          name: string
+          full_name: string
+          html_url: string
+          default_branch: string
+        }
+        ref: string
+      }
+      html_url: string
+    }
+    installation?: {
+      id: number
+    }
   },
   void, // return type
   'save_merged_pull_request'
@@ -243,6 +267,7 @@ export type ImportGitlabMergeRequests = BullMQJob<
       gitlab_access_token: string
       trello_access_token: string | null
       asana_access_token: string | null
+      has_unlimited_usage: boolean | null
     }
   },
   void, // return type


### PR DESCRIPTION
Previously was importing in a single job which would either:
- timeout
- fail on a single error

Now we'll import in separate jobs which should speed things up and be more resilient to errors.