### PR TITLE
feat: add cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "queue:dashboard": "dotenv -e .env.local tsx queue-dashboard.ts",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "cli": "dotenv -e .env.local tsx src/cli.ts"
   },
   "dependencies": {
     "@axiomhq/js": "^1.0.0-rc.3",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,8 @@
+import * as repl from 'node:repl'
+import { dbClient } from '@/database/client'
+import { dispatch } from '@/queue/default-queue'
+
+const replServer = repl.start('> ')
+
+replServer.context.dbClient = dbClient
+replServer.context.dispatch = dispatch


### PR DESCRIPTION
- Added a new script `"cli": "dotenv -e .env.local tsx src/cli.ts"` to the `package.json` file.
- Created a new file `src/cli.ts` that sets up a REPL server.
- The REPL server in `src/cli.ts` imports and makes `dbClient` and `dispatch` available in its context.