### PR TITLE
feat(PR): filter by target branch

### DIFF
--- a/src/lib/ai/chat/tools/get-list-pull-requests-tool.ts
+++ b/src/lib/ai/chat/tools/get-list-pull-requests-tool.ts
@@ -74,6 +74,16 @@ export function getListPullRequestsTool(params: getListPullRequestsToolParams) {
           query = query.where('target_branch', 'ilike', `%${targetBranch}%`)
         }
 
+        // If no target branch was given, search for PRs
+        // merged to default branch
+        if (!targetBranch) {
+          query = query.where((eb) =>
+            eb('was_merged_to_default_branch', '=', true)
+              // Assume no target_branch (legacy) to be default branch, which were the only PRs saved.
+              .or('target_branch', 'is', null),
+          )
+        }
+
         const pullRequests = await query.execute()
 
         logger.debug('Found PRs', {


### PR DESCRIPTION
- Added an optional `targetBranch` parameter to the `getListPullRequestsTool` function to filter pull requests by the target branch they were merged into.
- Modified the query construction to include the `targetBranch` filter if provided.
- Ensured that if no `targetBranch` is specified, the query defaults to searching for pull requests merged to the default branch or those with no `target_branch` specified (legacy behavior).