### PR TITLE
fix(PR): default branch query not working

### DIFF
--- a/src/app/(user)/review/_utils/get-pull-requests.ts
+++ b/src/app/(user)/review/_utils/get-pull-requests.ts
@@ -32,9 +32,11 @@ export async function getPullRequests(
       .where('homie.pull_request.organization_id', '=', organization.id)
       // Only send PRs merged to default branch
       .where((eb) =>
-        eb('was_merged_to_default_branch', '=', true)
+        eb.or([
+          eb('was_merged_to_default_branch', '=', true),
           // Assume no target_branch (legacy) to be default branch, which were the only PRs saved.
-          .or('target_branch', 'is', null),
+          eb('target_branch', 'is', null),
+        ]),
       )
       .innerJoin(
         'homie.contributor',

--- a/src/lib/ai/chat/tools/get-list-pull-requests-tool.ts
+++ b/src/lib/ai/chat/tools/get-list-pull-requests-tool.ts
@@ -75,12 +75,14 @@ export function getListPullRequestsTool(params: getListPullRequestsToolParams) {
         }
 
         // If no target branch was given, search for PRs
-        // merged to default branch
+        // merged to default
         if (!targetBranch) {
           query = query.where((eb) =>
-            eb('was_merged_to_default_branch', '=', true)
+            eb.or([
+              eb('was_merged_to_default_branch', '=', true),
               // Assume no target_branch (legacy) to be default branch, which were the only PRs saved.
-              .or('target_branch', 'is', null),
+              eb('target_branch', 'is', null),
+            ]),
           )
         }
 

--- a/src/lib/reporting/send-contributor-pull-requests.ts
+++ b/src/lib/reporting/send-contributor-pull-requests.ts
@@ -63,9 +63,11 @@ export async function sendContributorPullRequests(
       .where('merged_at', '>', cutOffDate)
       // Only send PRs merged to default branch
       .where((eb) =>
-        eb('was_merged_to_default_branch', '=', true)
+        eb.or([
+          eb('was_merged_to_default_branch', '=', true),
           // Assume no target_branch (legacy) to be default branch, which were the only PRs saved.
-          .or('target_branch', 'is', null),
+          eb('target_branch', 'is', null),
+        ]),
       )
       .select(['homie.pull_request.html_url', 'homie.pull_request.title'])
       .orderBy('merged_at')


### PR DESCRIPTION
- Updated the `getPullRequests` function to use an `or` condition for checking if a pull request was merged to the default branch or has a null `target_branch`.
- Modified the `getListPullRequestsTool` function to include an `or` condition for identifying pull requests merged to the default branch or with a null `target_branch`.
- Adjusted the `sendContributorPullRequests` function to apply an `or` condition for filtering pull requests merged to the default branch or with a null `target_branch`.