### PR TITLE
fix(PR List Commits): not including links

### DIFF
--- a/src/lib/ai/chat/get-answer.ts
+++ b/src/lib/ai/chat/get-answer.ts
@@ -67,6 +67,8 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
     organization: getOrganizationLogData(organization),
   })
 
+  let toolAnswer: string | null = null
+
   const tools = [
     getSearchGeneralContextTool({
       organization,
@@ -115,6 +117,9 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
     getListCommitsDeployedToBranchTool({
       organization,
       answerId,
+      onAnswer: (result) => {
+        toolAnswer = result
+      },
     }),
   ]
 
@@ -163,7 +168,8 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
     chat_history: chatHistory,
   })
 
-  const answer = result.output
+  // If a tool outputs an exact answer, use that instead of the LLM output.
+  const answer = toolAnswer ?? result.output
 
   if (organization.is_persona_enabled) {
     return rephraseWithPersona({


### PR DESCRIPTION
- Introduced a new variable `toolAnswer` in `get-answer.ts` to store exact answers from tools
- Implemented the `onAnswer` callback in `get-list-commits-deployed-to-branch-tool.ts` to pass exact answers back to `getAnswer`
- Modified `getAnswer` to prefer `toolAnswer` over the LLM output if available
- Updated commit processing in `get-list-commits-deployed-to-branch-tool.ts` to handle `merged_at` instead of `created_at` for better date formatting