### PR TITLE
fix(Tasks): log search task error

### DIFF
--- a/src/lib/ai/chat/tools/get-search-for-tasks-tool.ts
+++ b/src/lib/ai/chat/tools/get-search-for-tasks-tool.ts
@@ -150,6 +150,14 @@ export function getSearchForTasksTool(params: GetSearchForTasksToolParams) {
 
         return JSON.stringify(rankedDocuments)
       } catch (error) {
+        logger.debug('Failed to search for tasks', {
+          event: 'get_answer:search_tasks:task',
+          answer_id: answerId,
+          organization: getOrganizationLogData(organization),
+          search_term: searchTerm,
+          error: error instanceof Error ? error.message : error,
+        })
+
         return 'FAILED'
       }
     },


### PR DESCRIPTION
- Added a debug log statement to capture details when the search for tasks fails.
- The log includes the event name, answer ID, organization data, search term, and error message.