### PR TITLE
fix(Tasks): remove embedding task attributes

### DIFF
--- a/src/lib/ai/embed-task.ts
+++ b/src/lib/ai/embed-task.ts
@@ -2,7 +2,6 @@ import { getPineconeClient } from '@/lib/pinecone/pinecone-client'
 import { PineconeRecord, RecordMetadata } from '@pinecone-database/pinecone'
 import { createOpenAIEmbedder } from '@/lib/open-ai/create-open-ai-embedder'
 import { dbClient } from '@/database/client'
-import { getPriorityLabel } from '@/lib/tasks/task-priority'
 
 interface EmbedTaskParams {
   task: {
@@ -52,24 +51,7 @@ export async function embedTask(params: EmbedTaskParams) {
     .select(['name'])
     .executeTakeFirstOrThrow()
 
-  const attributes = [
-    `Task: ${task.name}`,
-    `Description: ${task.description}`,
-    `Status: ${status.name}`,
-    `Type: ${type.name}`,
-    `URL: ${task.html_url}`,
-    `Priority: ${getPriorityLabel(task.priority_level)}`,
-  ]
-
-  if (task.due_date) {
-    attributes.push(`Due Date: ${task.due_date}`)
-  }
-
-  if (task.completed_at) {
-    attributes.push(`Completed on: ${task.completed_at}`)
-  }
-
-  const text = attributes.join(', ')
+  const text = `${task.name}\n${task.description}`
 
   const embedding = await embedder.embedQuery(text)
 

--- a/src/lib/tasks/task-priority.ts
+++ b/src/lib/tasks/task-priority.ts
@@ -4,16 +4,3 @@ export const taskPriority = {
   normal: 2,
   nice_to_have: 3,
 } as const
-
-export const getPriorityLabel = (level: number) => {
-  switch (level) {
-    case 0:
-      return 'Critical Bug'
-    case 1:
-      return 'High'
-    case 2:
-      return 'Medium'
-    case 3:
-      return 'Low'
-  }
-}


### PR DESCRIPTION
Task attributes are filtered via metadata instead so embedding them as text just adds extra noise and reduces search accuracy.

- Removed the import statement for `getPriorityLabel` in the `embed-task.ts` file.
- Simplified the `attributes` array creation in `embed-task.ts` by removing task details such as status, type, URL, priority, due date, and completion date.
- Concatenated task name and description into a single `text` variable for embedding.
- Deleted the `getPriorityLabel` function and its related switch statement from `task-priority.ts`.