### PR TITLE
fix(Search): add search Pull Requests tool

### DIFF
--- a/src/lib/ai/chat/get-answer.ts
+++ b/src/lib/ai/chat/get-answer.ts
@@ -34,6 +34,7 @@ import { getSearchForTasksTool } from '@/lib/ai/chat/tools/get-search-for-tasks-
 import { getCreateTaskTool } from '@/lib/ai/chat/tools/get-create-task-tool'
 import { getListGithubReposTool } from '@/lib/ai/chat/tools/get-list-github-repos-tool'
 import { getListAsanaProjectsTool } from '@/lib/ai/chat/tools/get-list-asana-projects-tool'
+import { getSearchPullRequestsTool } from '@/lib/ai/chat/tools/get-search-pull-requests-tool'
 
 interface GetAnswerParams {
   organization: {
@@ -136,6 +137,10 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
       answerId,
     }),
     getListAsanaProjectsTool({
+      organization,
+      answerId,
+    }),
+    getSearchPullRequestsTool({
       organization,
       answerId,
     }),

--- a/src/lib/ai/chat/tools/get-search-pull-requests-tool.ts
+++ b/src/lib/ai/chat/tools/get-search-pull-requests-tool.ts
@@ -1,0 +1,141 @@
+import { TaskMetadata } from '@/lib/ai/embed-task'
+import { logger } from '@/lib/log/logger'
+import { createOpenAIEmbedder } from '@/lib/open-ai/create-open-ai-embedder'
+import { getOrganizationLogData } from '@/lib/organization/get-organization-log-data'
+import { getPineconeClient } from '@/lib/pinecone/pinecone-client'
+import { DynamicStructuredTool } from '@langchain/core/tools'
+import { CohereClient } from 'cohere-ai'
+import { z } from 'zod'
+import * as Sentry from '@sentry/nextjs'
+
+interface GetSearchPullRequestsToolParams {
+  organization: {
+    id: number
+    ext_gh_install_id: number | null
+  }
+  answerId: string
+}
+
+const numResults = 30
+
+/**
+ * Cohere relevance score to be included as results.
+ * Value from 0 - 1 (1 is most relevant)
+ * Reference: https://docs.cohere.com/docs/reranking-best-practices#interpreting-results
+ */
+const searchRelevanceThreshold = 0.4
+
+export function getSearchPullRequestsTool(
+  params: GetSearchPullRequestsToolParams,
+) {
+  const { organization, answerId } = params
+
+  return new DynamicStructuredTool({
+    name: 'search_for_pull_requests',
+    description: 'Search for Pull Requests',
+    schema: z.object({
+      searchTerm: z.string().describe('Term the pull request is related to'),
+    }),
+    func: async (params) => {
+      const { searchTerm } = params
+
+      logger.debug('Call - Search for pull requests', {
+        event: 'get_answer:search_pull_requests:call',
+        answer_id: answerId,
+        organization: getOrganizationLogData(organization),
+        search_term: searchTerm,
+      })
+
+      try {
+        const embedder = createOpenAIEmbedder({
+          modelName: 'text-embedding-3-large',
+        })
+        const embeddings = await embedder.embedQuery(searchTerm)
+        const index = getPineconeClient().Index(
+          process.env.PINECONE_INDEX_MAIN!,
+        )
+
+        const pineconeSearchFilters: Record<string, any> = {
+          organization_id: {
+            $eq: organization.id,
+          },
+          type: {
+            $in: ['pr_summary', 'pr_diff', 'mr_summary', 'mr_diff'],
+          },
+        }
+
+        const { matches } = await index.query({
+          vector: embeddings,
+          topK: numResults,
+          includeMetadata: true,
+          filter: pineconeSearchFilters,
+        })
+
+        if (matches.length === 0) {
+          logger.debug('No matching pull requests', {
+            event: 'get_answer:search_pull_requests:no_matches',
+            answer_id: answerId,
+            organization: getOrganizationLogData(organization),
+            search_term: searchTerm,
+          })
+
+          return 'No pull requests found'
+        }
+
+        logger.debug('Got matches', {
+          event: 'get_answer:search_pull_requests:found_matches',
+          answer_id: answerId,
+          organization: getOrganizationLogData(organization),
+          search_term: searchTerm,
+          matches,
+          filters: pineconeSearchFilters,
+        })
+
+        const cohere = new CohereClient({
+          token: process.env.COHERE_API_KEY,
+        })
+
+        const reranked = await cohere.rerank({
+          query: searchTerm,
+          documents: matches.map(
+            (match) => (match.metadata?.text ?? '') as string,
+          ),
+        })
+
+        const rankedDocuments = reranked.results.filter(
+          (result) => result.relevanceScore > searchRelevanceThreshold,
+        )
+
+        logger.debug('Ranked and filtered results', {
+          event: 'get_answer:search_pull_requests:ranked_results',
+          answer_id: answerId,
+          organization: getOrganizationLogData(organization),
+          search_term: searchTerm,
+          matches,
+          reranked_raw: reranked.results.map(
+            (result) =>
+              matches[result.index].metadata as unknown as TaskMetadata,
+          ),
+          search_relevance_threshold: searchRelevanceThreshold,
+          result: rankedDocuments,
+          filters: pineconeSearchFilters,
+        })
+
+        return JSON.stringify(rankedDocuments)
+      } catch (error) {
+        Sentry.captureException(error)
+
+        logger.debug('Failed to search for tasks', {
+          event: 'get_answer:search_pull_requests:failed',
+          answer_id: answerId,
+          organization: getOrganizationLogData(organization),
+          search_term: searchTerm,
+          error: error instanceof Error ? error.message : error,
+          stack_trace: error instanceof Error ? error.stack?.split('\n') : null,
+        })
+
+        return 'FAILED'
+      }
+    },
+  })
+}

--- a/src/lib/gitlab/embed-gitlab-diff.ts
+++ b/src/lib/gitlab/embed-gitlab-diff.ts
@@ -20,7 +20,7 @@ export async function embedGitlabDiff(params: EmbedGitlabDiff) {
   const { diff, summary, pullRequest, organization_id, contributor } = params
 
   const metadata = {
-    type: 'mr_diff',
+    type: 'pr_diff',
     organization_id,
     pull_request_id: pullRequest.id,
     ext_gitlab_merge_request_id: pullRequest.ext_gitlab_merge_request_id,

--- a/src/lib/gitlab/save-merged-merge-request.ts
+++ b/src/lib/gitlab/save-merged-merge-request.ts
@@ -100,7 +100,7 @@ export async function saveMergedMergeRequest(
   const wasMergedToDefaultBranch = mergeRequest.target_branch === defaultBranch
 
   const embed_metadata = {
-    type: 'mr_summary',
+    type: 'pr_summary',
     title: mergeRequest.title,
     url: mergeRequest.web_url,
     ext_gitlab_merge_request_id: mergeRequest.id,


### PR DESCRIPTION
After adding search for tasks tool, the LLM would default to using it to search for PRs instead of general context. This PR adds a search PRs tool too.

- Added a new tool to search for pull requests in the chat AI system, including functionality to embed queries, query a Pinecone index, and rerank results using Cohere.