### PR TITLE
fix(AI): force tool choice to include context when answering

### DIFF
--- a/src/lib/ai/chat/get-answer.ts
+++ b/src/lib/ai/chat/get-answer.ts
@@ -149,6 +149,7 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
   const model = createOpenAIChatClient({ model: 'gpt-4o-2024-05-13' })
   const modelWithFunctions = model.bind({
     functions: tools.map((tool) => convertToOpenAIFunction(tool)),
+    // Require a tool choice to add more context, and avoid generic answers.
     tool_choice: 'required',
   })
 


### PR DESCRIPTION
Sometimes Homie will skip calling a tool and provide generic answers. This PR forces it to call a tool which should fallback to searching general context, and result in more relevant answers.