### PR TITLE
fix(AI): switch from functions to tools

### DIFF
--- a/src/lib/ai/chat/get-answer.ts
+++ b/src/lib/ai/chat/get-answer.ts
@@ -13,7 +13,7 @@ import { formatToOpenAIFunctionMessages } from 'langchain/agents/format_scratchp
 import { OpenAIFunctionsAgentOutputParser } from 'langchain/agents/openai/output_parser'
 
 import { createOpenAIChatClient } from '@/lib/open-ai/create-open-ai-chat-client'
-import { convertToOpenAIFunction } from '@langchain/core/utils/function_calling'
+import { convertToOpenAITool } from '@langchain/core/utils/function_calling'
 import { rephraseWithPersona } from '@/lib/ai/rephrase-with-persona'
 import { getListPullRequestsTool } from '@/lib/ai/chat/tools/get-list-pull-requests-tool'
 import { getRememberConversationTool } from '@/lib/ai/chat/tools/get-remember-conversation-tool'
@@ -148,7 +148,7 @@ export async function getAnswer(params: GetAnswerParams): Promise<string> {
 
   const model = createOpenAIChatClient({ model: 'gpt-4o-2024-05-13' })
   const modelWithFunctions = model.bind({
-    functions: tools.map((tool) => convertToOpenAIFunction(tool)),
+    tools: tools.map((tool) => convertToOpenAITool(tool)),
     // Require a tool choice to add more context, and avoid generic answers.
     tool_choice: 'required',
   })

--- a/src/lib/ai/chat/tools/get-search-general-context-tool.ts
+++ b/src/lib/ai/chat/tools/get-search-general-context-tool.ts
@@ -3,7 +3,7 @@ import { logger } from '@/lib/log/logger'
 import { getOrganizationLogData } from '@/lib/organization/get-organization-log-data'
 import { DynamicTool } from '@langchain/core/tools'
 
-interface getSearchGeneralContextToolParams {
+interface GetSearchGeneralContextToolParams {
   organization: {
     id: number
   }
@@ -11,7 +11,7 @@ interface getSearchGeneralContextToolParams {
 }
 
 export function getSearchGeneralContextTool(
-  params: getSearchGeneralContextToolParams,
+  params: GetSearchGeneralContextToolParams,
 ) {
   const { organization, answerId } = params
   return new DynamicTool({


### PR DESCRIPTION
`functions` is depcreated, this updates openai client to use `tools` instead. They seem to be functionally equivalent, except tools support the `tool_choice` param.