### PR TITLE
fix(Tasks/Find Duplicate): only searching open tasks

### DIFF
--- a/src/queue/handlers/handle-check-for-duplicate-task.ts
+++ b/src/queue/handlers/handle-check-for-duplicate-task.ts
@@ -131,7 +131,6 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
     .selectFrom('homie.task')
     .where('organization_id', '=', task.organization_id)
     .where('homie.task.id', '=', duplicateTaskId)
-    .where('task_status_id', '=', taskStatus.open)
     .select(['name', 'description', 'html_url'])
     .executeTakeFirst()
 


### PR DESCRIPTION
Previously only searching open tasks, but we should check closed ones for duplicates too