### PR TITLE
fix(Infra/Worker): not terminating when stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     build:
       context: .
       dockerfile: worker.Dockerfile
+      args:
+        WATCH_MODE: true
     container_name: homie_worker
     volumes:
       - .:/app

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "billing:create-plans": "dotenv -e .env.local tsx src/lib/billing/create-plans.ts",
     "db:seed": "dotenv -e .env.local tsx src/database/scripts/seed.ts",
     "db:reset": "npm run db:drop && npm run db:migrate && npm run db:generate && npm run db:seed && npm run billing:create-plans",
-    "queue:work": "dotenv -e .env.local tsx -- --watch src/queue/work.ts",
+    "queue:work": "dotenv -e .env.local tsx -- src/queue/work.ts",
     "queue:schedule-jobs": "dotenv -e .env.local tsx src/queue/schedule-jobs.ts",
     "format": "next lint --fix && prettier --write --ignore-path .gitignore .",
     "typecheck": "tsc --noEmit",

--- a/worker-entrypoint.sh
+++ b/worker-entrypoint.sh
@@ -2,4 +2,9 @@
 
 npm run queue:schedule-jobs
 npm run queue:dashboard &
-npm run queue:work
+
+if [[ $WATCH_MODE -eq "true" ]]; then
+   npx dotenv -e .env.local tsx -- --watch src/queue/work.ts
+else
+  npm run queue:work
+fi

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -3,6 +3,9 @@ FROM node:20.10.0
 ARG SENTRY_AUTH_TOKEN
 ENV SENTRY_AUTH_TOKEN $SENTRY_AUTH_TOKEN
 
+ARG WATCH_MODE
+ENV WATCH_MODE $WATCH_MODE
+
 # Setting working directory. All the path will be relative to WORKDIR
 WORKDIR /app
 


### PR DESCRIPTION
Workers suddenly stop from time to time. Checking logs shows that an error is thrown, and the script is terminated... BUT the process is still running, which prevents ECS from restarting the container. This might be due to running `tsx` in watch mode. 

This PR updates the worker image to **not** run in watch mode on prod.

![CleanShot 2024-08-11 at 01 44 21@2x](https://github.com/user-attachments/assets/98daa18f-bb97-4f12-beaf-4f2431427595)
