### PR TITLE
fix(Task/Search): missing relevant fields

### DIFF
--- a/src/lib/ai/chat/tools/get-search-for-tasks-tool.ts
+++ b/src/lib/ai/chat/tools/get-search-for-tasks-tool.ts
@@ -181,13 +181,11 @@ export function getSearchForTasksTool(params: GetSearchForTasksToolParams) {
           organization: getOrganizationLogData(organization),
           search_term: searchTerm,
           matches,
-          reranked_raw: reranked.results.map(
-            (result) =>
-              {
-                const metadata = matches[result.index].metadata as unknown as TaskMetadata
-  return {name: metadata.text, id: metadata.task_id}
-              }
-          ),
+          reranked_raw: reranked.results.map((result) => {
+            const metadata = matches[result.index]
+              .metadata as unknown as TaskMetadata
+            return { name: metadata.text, id: metadata.task_id }
+          }),
           search_relevance_threshold: searchRelevanceThreshold,
           result: rankedDocuments,
           include_completed_tasks: includeCompletedTasks,
@@ -195,7 +193,14 @@ export function getSearchForTasksTool(params: GetSearchForTasksToolParams) {
           filters: pineconeSearchFilters,
         })
 
-        return JSON.stringify(rankedDocuments)
+        const tasks = rankedDocuments.map((taskMetadata) => ({
+          id: taskMetadata.task_id,
+          name: taskMetadata.name,
+          description: taskMetadata.description,
+          url: taskMetadata.html_url,
+        }))
+
+        return JSON.stringify(tasks)
       } catch (error) {
         Sentry.captureException(error)
 

--- a/src/lib/ai/embed-task.ts
+++ b/src/lib/ai/embed-task.ts
@@ -21,6 +21,8 @@ interface EmbedTaskParams {
 
 export interface TaskMetadata extends RecordMetadata {
   type: 'task'
+  name: string
+  description: string
   organization_id: number
   task_id: number
   task_status: string
@@ -57,6 +59,8 @@ export async function embedTask(params: EmbedTaskParams) {
 
   const metadata: TaskMetadata = {
     type: 'task',
+    name: task.name,
+    description: task.description,
     organization_id: task.organization_id,
     task_id: task.id,
     task_status: status.name,
@@ -66,6 +70,7 @@ export async function embedTask(params: EmbedTaskParams) {
     created_at: task.created_at.toISOString(),
     due_date: task.due_date?.toISOString() ?? '',
     completed_at: task.completed_at?.toISOString() ?? '',
+    url: task.html_url,
   }
 
   const record: PineconeRecord = {

--- a/src/queue/handlers/handle-save-merged-pull-request.ts
+++ b/src/queue/handlers/handle-save-merged-pull-request.ts
@@ -6,7 +6,6 @@ import { logger } from '@/lib/log/logger'
 import { SaveMergedPullRequest } from '@/queue/jobs'
 import { getIsOverPlanContributorLimit } from '@/lib/billing/get-is-over-plan-contributor-limit'
 import { dispatch } from '@/queue/dispatch'
-import { config } from '@/config'
 
 export async function handleSaveMergedPullRequest(job: SaveMergedPullRequest) {
   const { pull_request, installation } = job.data


### PR DESCRIPTION
Previously metadata only contained id + text, and the LLM would regularly only return task ids. 

This PR returns the name, and description as separate fields, as well as including the task url.