### PR TITLE
fix(Logging): remove data prop

### DIFF
--- a/src/lib/gitlab/save-merged-merge-request.ts
+++ b/src/lib/gitlab/save-merged-merge-request.ts
@@ -49,10 +49,8 @@ export async function saveMergedMergeRequest(
 
   logger.debug('Start Save merge request', {
     event: 'save_merge_request.start',
-    data: {
-      organization: getOrganizationLogData(organization),
-      merge_request: getMergeRequestLogData(mergeRequest),
-    },
+    organization: getOrganizationLogData(organization),
+    merge_request: getMergeRequestLogData(mergeRequest),
   })
 
   // Create contributor

--- a/src/queue/handlers/handle-calculate-task-complexity.ts
+++ b/src/queue/handlers/handle-calculate-task-complexity.ts
@@ -59,15 +59,13 @@ export async function handleCalculateTaskComplexity(
 
   logger.debug('Checked complexity', {
     event: 'calculate_task_complexity:calculated',
-    data: {
-      task,
-      organization: getOrganizationLogData(organization),
-      ai_call: true,
-      prompt: calculateComplexityResult.prompt,
-      complexity_score: calculateComplexityResult.score,
-      failed: Boolean(calculateComplexityResult.error),
-      error: calculateComplexityResult.error,
-    },
+    task,
+    organization: getOrganizationLogData(organization),
+    ai_call: true,
+    prompt: calculateComplexityResult.prompt,
+    complexity_score: calculateComplexityResult.score,
+    failed: Boolean(calculateComplexityResult.error),
+    error: calculateComplexityResult.error,
   })
 
   if (!calculateComplexityResult.score) {

--- a/src/queue/handlers/handle-check-for-duplicate-task.ts
+++ b/src/queue/handlers/handle-check-for-duplicate-task.ts
@@ -48,10 +48,8 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
 
   logger.debug('Check for duplicate task', {
     event: 'check_for_duplicate_task:start',
-    data: {
-      task,
-      organization: getOrganizationLogData(organization),
-    },
+    task,
+    organization: getOrganizationLogData(organization),
   })
 
   const searchTerm = `${task.name}\n${task.description}`
@@ -86,10 +84,8 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
   if (matches.length === 0) {
     logger.debug('No matching tasks found', {
       event: 'check_for_duplicate_task:no_match',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-      },
+      task,
+      organization: getOrganizationLogData(organization),
     })
 
     // No matching duplicate task
@@ -115,11 +111,9 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
   if (rankedDocuments.length === 0) {
     logger.debug('No potential duplicates above threshold', {
       event: 'check_for_duplicate_task:no_potential_duplicates',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-        matches: matches.map((match) => match.metadata),
-      },
+      task,
+      organization: getOrganizationLogData(organization),
+      matches: matches.map((match) => match.metadata),
     })
     return
   }
@@ -136,12 +130,10 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
   if (!duplicateTask) {
     logger.debug('Missing duplicate task', {
       event: 'check_for_duplicate_task:missing_duplicate_task',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-        matches: matches.map((match) => match.metadata),
-        duplicate_task_id: duplicateTaskId,
-      },
+      task,
+      organization: getOrganizationLogData(organization),
+      matches: matches.map((match) => match.metadata),
+      duplicate_task_id: duplicateTaskId,
     })
     return
   }
@@ -174,26 +166,22 @@ export async function handleCheckForDuplicateTask(job: CheckForDuplicateTask) {
   if (!checkIsDuplicateResult.isDuplicate) {
     logger.debug('Check: Not duplicate', {
       event: 'check_for_duplicate_task:not_duplicate',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-        matches: matches.map((match) => match.metadata),
-        is_duplicate: false,
-        duplicate_task: duplicateTask,
-      },
+      task,
+      organization: getOrganizationLogData(organization),
+      matches: matches.map((match) => match.metadata),
+      is_duplicate: false,
+      duplicate_task: duplicateTask,
     })
     return
   }
 
   logger.debug('Found duplicate', {
     event: 'check_for_duplicate_task:found_duplicate',
-    data: {
-      task,
-      organization: getOrganizationLogData(organization),
-      matches: matches.map((match) => match.metadata),
-      duplicate_task: duplicateTask,
-      is_duplicate: true,
-    },
+    task,
+    organization: getOrganizationLogData(organization),
+    matches: matches.map((match) => match.metadata),
+    duplicate_task: duplicateTask,
+    is_duplicate: true,
   })
 
   const alreadyNotified = await dbClient

--- a/src/queue/handlers/handle-check-unclosed-task.ts
+++ b/src/queue/handlers/handle-check-unclosed-task.ts
@@ -23,12 +23,10 @@ export async function handleCheckForUnclosedTask(job: CheckForUnclosedTask) {
 
   logger.debug('Check for unclosed tasks', {
     event: 'check_for_unclosed_tasks:start',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-      organization: getOrganizationLogData({
-        id: pull_request.organization_id,
-      }),
-    },
+    pull_request: getPullRequestLogData(pull_request),
+    organization: getOrganizationLogData({
+      id: pull_request.organization_id,
+    }),
   })
 
   const organization = await dbClient
@@ -87,10 +85,8 @@ export async function handleCheckForUnclosedTask(job: CheckForUnclosedTask) {
   if (matches.length === 0) {
     logger.debug('No matching tasks', {
       event: 'check_for_unclosed_tasks:no_matches',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
 
     // No matching unclosed tasks
@@ -116,12 +112,10 @@ export async function handleCheckForUnclosedTask(job: CheckForUnclosedTask) {
   if (rankedDocuments.length === 0) {
     logger.debug('No potential matching tasks above threshold', {
       event: 'check_for_duplicate_task:no_potential_target_tasks',
-      data: {
-        organization: getOrganizationLogData({
-          id: pull_request.organization_id,
-        }),
-        matches: matches.map((match) => match.metadata),
-      },
+      organization: getOrganizationLogData({
+        id: pull_request.organization_id,
+      }),
+      matches: matches.map((match) => match.metadata),
     })
     return
   }

--- a/src/queue/handlers/handle-close-merge-request.ts
+++ b/src/queue/handlers/handle-close-merge-request.ts
@@ -12,9 +12,7 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
 
   logger.debug('Close merge request', {
     event: 'close_merge_request:start',
-    data: {
-      merge_request: getMergeRequestLogData(merge_request),
-    },
+    merge_request: getMergeRequestLogData(merge_request),
   })
 
   const project = await dbClient
@@ -28,10 +26,8 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
   if (!project) {
     logger.debug('Missing project; is the project enabled?', {
       event: 'close_merge_request.missing_project',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -40,11 +36,9 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan contributor limit', {
       event: 'close_merge_request.org_over_plan_limit',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -68,11 +62,9 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
 
     logger.debug('Closed existing merge request', {
       event: 'close_merge_request:closed_existing_mr',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -86,11 +78,9 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
   if (!mergeRequestInfo) {
     logger.debug('missing gitlab merge request data', {
       event: 'close_merge_request:missing_merge_request_data',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -101,11 +91,9 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
   if (!author) {
     logger.debug('missing gitlab user info', {
       event: 'close_merge_request:missing_gitlab_user_info',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -162,10 +150,8 @@ export async function handleCloseMergeRequest(job: CloseMergeRequest) {
 
   logger.debug('Saved untracked closed MR', {
     event: 'close_merge_request:save_untracked_pr',
-    data: {
-      project: getProjectLogData(project),
-      merge_request: getMergeRequestLogData(merge_request),
-      organization: getOrganizationLogData(organization),
-    },
+    project: getProjectLogData(project),
+    merge_request: getMergeRequestLogData(merge_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-closed-pull-request.ts
+++ b/src/queue/handlers/handle-closed-pull-request.ts
@@ -28,9 +28,7 @@ export async function handleClosePullRequest(job: ClosePullRequest) {
   if (!organization) {
     logger.debug('Missing organization', {
       event: 'handle_close_pull_request:start',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -38,10 +36,8 @@ export async function handleClosePullRequest(job: ClosePullRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan limit', {
       event: 'handle_close_pull_request:org_over_plan_limit',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -63,9 +59,7 @@ export async function handleClosePullRequest(job: ClosePullRequest) {
 
     logger.debug('Closed existing pr', {
       event: 'handle_close_pull_request:closed_existing_pr',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -132,10 +126,8 @@ export async function handleClosePullRequest(job: ClosePullRequest) {
 
     logger.debug('Saved untracked closed PR', {
       event: 'handle_close_pull_request:save_untracked_pr',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return

--- a/src/queue/handlers/handle-generate-open-merge-request-summary.ts
+++ b/src/queue/handlers/handle-generate-open-merge-request-summary.ts
@@ -27,10 +27,8 @@ export async function handleGenerateOpenMergeRequestSummary(
   if (!project) {
     logger.debug('Missing project; is the project enabled?', {
       event: 'generate_open_merge_request_summary.missing_project',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return

--- a/src/queue/handlers/handle-import-pull-requests.ts
+++ b/src/queue/handlers/handle-import-pull-requests.ts
@@ -7,14 +7,15 @@ import { ImportPullRequests } from '@/queue/jobs'
 import { dispatch } from '@/queue/dispatch'
 
 export async function handleImportPullRequests(job: ImportPullRequests) {
+  const { github_organization } = job.data
+
   logger.debug('Start pull request import', {
     event: 'import_pull_requests.start',
-    data: {
-      job,
+    organization: {
+      id: github_organization.organization_id,
+      ext_gh_install_id: github_organization.ext_gh_install_id,
     },
   })
-
-  const { github_organization } = job.data
 
   const organization = await dbClient
     .selectFrom('homie.organization')
@@ -45,8 +46,8 @@ export async function handleImportPullRequests(job: ImportPullRequests) {
   if (!organization) {
     logger.debug('Missing organization - abort', {
       event: 'import_pull_requests.missing_organization',
-      data: {
-        job,
+      organization: {
+        id: github_organization.organization_id,
         ext_gh_install_id: github_organization.ext_gh_install_id,
       },
     })
@@ -80,12 +81,8 @@ export async function handleImportPullRequests(job: ImportPullRequests) {
       if (!pullRequest.user) {
         logger.debug('Missing pull request user - skipping', {
           event: 'import_pull_requests.missing_user',
-          data: {
-            job,
-            ext_gh_install_id: github_organization.ext_gh_install_id,
-            organization: getOrganizationLogData(organization),
-            pull_request: getPullRequestLogData(pullRequest),
-          },
+          organization: getOrganizationLogData(organization),
+          pull_request: getPullRequestLogData(pullRequest),
         })
         continue
       }

--- a/src/queue/handlers/handle-reopen-merge-request.ts
+++ b/src/queue/handlers/handle-reopen-merge-request.ts
@@ -12,9 +12,7 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
 
   logger.debug('Reopen merge request', {
     event: 'reopen_merge_Request:start',
-    data: {
-      merge_request: getMergeRequestLogData(merge_request),
-    },
+    merge_request: getMergeRequestLogData(merge_request),
   })
 
   const project = await dbClient
@@ -28,10 +26,8 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
   if (!project) {
     logger.debug('Missing project; is the project enabled?', {
       event: 'reopen_merge_Request.missing_project',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -40,11 +36,9 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan contributor limit', {
       event: 'reopen_merge_Request.org_over_plan_limit',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -68,11 +62,9 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
 
     logger.debug('Reopen existing merge request', {
       event: 'reopen_merge_Request:reopened_existing_mr',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -86,11 +78,9 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
   if (!mergeRequestInfo) {
     logger.debug('missing gitlab merge request data', {
       event: 'reopen_merge_Request:missing_merge_request_data',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -101,11 +91,9 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
   if (!author) {
     logger.debug('missing gitlab user info', {
       event: 'reopen_merge_Request:missing_gitlab_user_info',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -161,10 +149,8 @@ export async function handleReopenMergeRequest(job: ReopenMergeRequest) {
 
   logger.debug('Saved untracked reopened MR', {
     event: 'reopen_merge_Request:save_untracked_pr',
-    data: {
-      project: getProjectLogData(project),
-      merge_request: getMergeRequestLogData(merge_request),
-      organization: getOrganizationLogData(organization),
-    },
+    project: getProjectLogData(project),
+    merge_request: getMergeRequestLogData(merge_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-reopen-pull-request.ts
+++ b/src/queue/handlers/handle-reopen-pull-request.ts
@@ -28,9 +28,7 @@ export async function handleReopenPullRequest(job: ReopenPullRequest) {
   if (!organization) {
     logger.debug('Missing organization', {
       event: 'handle_reopen_pull_request:start',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -38,10 +36,8 @@ export async function handleReopenPullRequest(job: ReopenPullRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan limit', {
       event: 'handle_reopen_pull_request:org_over_plan_limit',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -63,9 +59,7 @@ export async function handleReopenPullRequest(job: ReopenPullRequest) {
 
     logger.debug('Reopened existing pr', {
       event: 'handle_reopen_pull_request:reopened_existing_pr',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -130,9 +124,7 @@ export async function handleReopenPullRequest(job: ReopenPullRequest) {
 
   logger.debug('Saved untracked reopened PR', {
     event: 'handle_reopen_pull_request:save_untracked_pr',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-      organization: getOrganizationLogData(organization),
-    },
+    pull_request: getPullRequestLogData(pull_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-save-merged-merge-request.ts
+++ b/src/queue/handlers/handle-save-merged-merge-request.ts
@@ -19,9 +19,7 @@ export async function handleSaveMergedMergeRequest(
 
   logger.debug('Start save merged MR', {
     event: 'save_merged_merge_request.start',
-    data: {
-      merge_request: getMergeRequestLogData(merge_request),
-    },
+    merge_request: getMergeRequestLogData(merge_request),
   })
 
   const project = await dbClient
@@ -35,10 +33,8 @@ export async function handleSaveMergedMergeRequest(
   if (!project) {
     logger.debug('Missing project; is the project enabled?', {
       event: 'save_merged_merge_request.missing_project',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -47,10 +43,8 @@ export async function handleSaveMergedMergeRequest(
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan contributor limit', {
       event: 'save_merged_merge_request.org_over_plan_limit',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }

--- a/src/queue/handlers/handle-save-merged-pull-request.ts
+++ b/src/queue/handlers/handle-save-merged-pull-request.ts
@@ -12,9 +12,7 @@ export async function handleSaveMergedPullRequest(job: SaveMergedPullRequest) {
 
   logger.debug('Start save merged PR', {
     event: 'save_merged_pull_request.start',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-    },
+    pull_request: getPullRequestLogData(pull_request),
   })
 
   const organization = await dbClient
@@ -59,9 +57,7 @@ export async function handleSaveMergedPullRequest(job: SaveMergedPullRequest) {
   if (!organization) {
     logger.debug('Missing organization', {
       event: 'save_merged_pull_request.missing_organization',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -69,10 +65,8 @@ export async function handleSaveMergedPullRequest(job: SaveMergedPullRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan contributor limit', {
       event: 'save_merged_merge_request.org_over_plan_limit',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -104,9 +98,7 @@ export async function handleSaveMergedPullRequest(job: SaveMergedPullRequest) {
 
   logger.debug('Finished saving merged PR', {
     event: 'save_merged_pull_request.complete',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-      organization: getOrganizationLogData(organization),
-    },
+    pull_request: getPullRequestLogData(pull_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-save-opened-merge-request.ts
+++ b/src/queue/handlers/handle-save-opened-merge-request.ts
@@ -14,10 +14,8 @@ export async function handleSaveOpenedMergeRequest(
 
   logger.debug('Start save opened PR', {
     event: 'save_opened_merge_request.start',
-    data: {
-      organization: getOrganizationLogData(organization),
-      merge_request: getMergeRequestLogData(merge_request),
-    },
+    organization: getOrganizationLogData(organization),
+    merge_request: getMergeRequestLogData(merge_request),
   })
 
   const project = await dbClient
@@ -31,10 +29,8 @@ export async function handleSaveOpenedMergeRequest(
   if (!project) {
     logger.debug('Missing project; is the project enabled?', {
       event: 'save_opened_merge_request.missing_project',
-      data: {
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -43,11 +39,9 @@ export async function handleSaveOpenedMergeRequest(
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan limit', {
       event: 'save_opened_merge_request.org_over_plan_limit',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -63,11 +57,9 @@ export async function handleSaveOpenedMergeRequest(
   if (!mergeRequestData) {
     logger.debug('missing gitlab merge request data', {
       event: 'save_opened_merge_request.missing_merge_request_data',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -76,11 +68,9 @@ export async function handleSaveOpenedMergeRequest(
   if (!author) {
     logger.debug('missing gitlab user info', {
       event: 'save_opened_merge_request.missing_gitlab_user_info',
-      data: {
-        project: getProjectLogData(project),
-        merge_request: getMergeRequestLogData(merge_request),
-        organization: getOrganizationLogData(organization),
-      },
+      project: getProjectLogData(project),
+      merge_request: getMergeRequestLogData(merge_request),
+      organization: getOrganizationLogData(organization),
     })
 
     return
@@ -136,10 +126,8 @@ export async function handleSaveOpenedMergeRequest(
 
   logger.debug('Finished saving opened MR', {
     event: 'save_opened_merge_request.complete',
-    data: {
-      project: getProjectLogData(project),
-      merge_request: getMergeRequestLogData(merge_request),
-      organization: getOrganizationLogData(organization),
-    },
+    project: getProjectLogData(project),
+    merge_request: getMergeRequestLogData(merge_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-save-opened-pull-request.ts
+++ b/src/queue/handlers/handle-save-opened-pull-request.ts
@@ -11,9 +11,7 @@ export async function handleSaveOpenedPullRequest(job: SaveOpenedPullRequest) {
 
   logger.debug('Start save opened PR', {
     event: 'save_opened_pull_request:start',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-    },
+    pull_request: getPullRequestLogData(pull_request),
   })
 
   const organization = await dbClient
@@ -40,9 +38,7 @@ export async function handleSaveOpenedPullRequest(job: SaveOpenedPullRequest) {
   if (!organization) {
     logger.debug('Missing organization', {
       event: 'save_opened_pull_request.missing_organization',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-      },
+      pull_request: getPullRequestLogData(pull_request),
     })
     return
   }
@@ -50,10 +46,8 @@ export async function handleSaveOpenedPullRequest(job: SaveOpenedPullRequest) {
   if (await getIsOverPlanContributorLimit({ organization })) {
     logger.debug('org over plan limit', {
       event: 'save_opened_pull_request:org_over_plan_limit',
-      data: {
-        pull_request: getPullRequestLogData(pull_request),
-        organization: getOrganizationLogData(organization),
-      },
+      pull_request: getPullRequestLogData(pull_request),
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -117,9 +111,7 @@ export async function handleSaveOpenedPullRequest(job: SaveOpenedPullRequest) {
 
   logger.debug('Finished saving opened PR', {
     event: 'save_opened_pull_request:complete',
-    data: {
-      pull_request: getPullRequestLogData(pull_request),
-      organization: getOrganizationLogData(organization),
-    },
+    pull_request: getPullRequestLogData(pull_request),
+    organization: getOrganizationLogData(organization),
   })
 }

--- a/src/queue/handlers/handle-send-similar-pull-requests-for-task.ts
+++ b/src/queue/handlers/handle-send-similar-pull-requests-for-task.ts
@@ -70,10 +70,8 @@ export async function handleSendSimilarPullRequestsForTask(
 
   logger.debug('Send similar pull requests', {
     event: 'send_similar_pull_requests:start',
-    data: {
-      task,
-      organization: getOrganizationLogData(organization),
-    },
+    task,
+    organization: getOrganizationLogData(organization),
   })
 
   const searchTerm = `${task.name}\n${task.description}`
@@ -105,10 +103,8 @@ export async function handleSendSimilarPullRequestsForTask(
   if (matches.length === 0) {
     logger.debug('No similar pull requests found', {
       event: 'send_similar_pull_requests:none',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-      },
+      task,
+      organization: getOrganizationLogData(organization),
     })
 
     // No similar pull requests
@@ -137,10 +133,8 @@ export async function handleSendSimilarPullRequestsForTask(
   if (rankedDocuments.length === 0) {
     logger.debug('No pull requests above score threshold', {
       event: 'send_similar_pull_requests:none_above_threshold',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-      },
+      task,
+      organization: getOrganizationLogData(organization),
     })
     return
   }
@@ -236,11 +230,9 @@ export async function handleSendSimilarPullRequestsForTask(
   if (pullRequests.length === 0) {
     logger.debug('No similar pull requests.', {
       event: 'send_similar_pull_requests:none_similar',
-      data: {
-        task,
-        organization: getOrganizationLogData(organization),
-        pullRequests,
-      },
+      task,
+      organization: getOrganizationLogData(organization),
+      pullRequests,
     })
 
     return
@@ -248,11 +240,9 @@ export async function handleSendSimilarPullRequestsForTask(
 
   logger.debug('Found similar pull requests', {
     event: 'send_similar_pull_requests:found_matches',
-    data: {
-      task,
-      organization: getOrganizationLogData(organization),
-      pullRequests,
-    },
+    task,
+    organization: getOrganizationLogData(organization),
+    pullRequests,
   })
 
   // Github Issue


### PR DESCRIPTION
Some logs were called with a `data` property, and some weren't. This PR addresses the inconsistency by removing the `data` prop everywhere except for generic events, such as jobs, or requests.