### PR TITLE
fix(Task/ETA): missing org complexity velocity

### DIFF
--- a/src/queue/handlers/handle-calculate-organization-complexity-score-per-day.ts
+++ b/src/queue/handlers/handle-calculate-organization-complexity-score-per-day.ts
@@ -4,7 +4,7 @@ import { subDays } from 'date-fns'
 export async function handleCalculateOrganizationComplexityScorePerDay() {
   // Scores are calculated weekly.
   // queue/schedule-jobs.ts for cron pattern
-  const lastWeek = subDays(new Date(), 1)
+  const lastWeek = subDays(new Date(), 7)
 
   const organizations = await dbClient
     .selectFrom('homie.organization')


### PR DESCRIPTION
Complexity scores were missing. Likely due to pull request cutoff date only being a day, but job was run weekly