### PR TITLE
fix(PR): referenced Slack message content formatting

### DIFF
--- a/src/lib/slack/send-slack-pr-merged-message.ts
+++ b/src/lib/slack/send-slack-pr-merged-message.ts
@@ -24,11 +24,10 @@ export async function sendSlackPRMergedMessage(
     thread_ts: slackLink.threadTS || slackLink.messageTS,
     blocks: [
       {
-        type: 'header',
+        type: 'section',
         text: {
-          type: 'plain_text',
-          text: 'Pull Request referencing this message has been merged 🍕.',
-          emoji: true,
+          type: 'mrkdwn',
+          text: 'Pull Request referencing this message has been merged:',
         },
       },
       {


### PR DESCRIPTION
Updates the formatting of 'referenced by message' content that is sent to Slack when a PR is merged.

Previously:

![CleanShot 2024-09-25 at 14 14 41@2x](https://github.com/user-attachments/assets/8ccc9e3f-13d7-473c-9703-4ccb8ae3a0d0)

This PR:

![CleanShot 2024-09-25 at 14 15 08@2x](https://github.com/user-attachments/assets/e7b2be6c-143d-45de-ad43-1e0f42559484)

