### PR TITLE
fix(Slack): add im:history scope to install URL for group DMs

### DIFF
--- a/src/lib/slack/get-slack-install-url.ts
+++ b/src/lib/slack/get-slack-install-url.ts
@@ -6,6 +6,8 @@ const appScopes = [
   'groups:history',
   'incoming-webhook',
   'users:read',
+  'im:history',
+  'mpim:history',
 ]
 
 const baseUrl = 'https://slack.com/oauth/v2/authorize'


### PR DESCRIPTION
Scope is required in app but was missing from oauth url