### PR TITLE
fix(Asana): helpful PR comment showing raw text

### DIFF
--- a/src/lib/asana/post-similar-pull-requests-asana-task-comment.ts
+++ b/src/lib/asana/post-similar-pull-requests-asana-task-comment.ts
@@ -19,6 +19,6 @@ export async function postSimilarPullRequestsAsanaTaskComment(
   await postAsanaTaskComment({
     asanaAccessToken: organization.asana_access_token,
     extAsanaTaskId: targetTask.ext_asana_task_id,
-    html: `<body>Here are some pull requests that might be helpful reference for this task: <br/>${pullRequests.map((pullRequest) => `<a href="${pullRequest.html_url}">${pullRequest.title}</a>`).join('<br/>')}</body>`,
+    html: `<body>Here are some pull requests that might be helpful reference for this task: \n${pullRequests.map((pullRequest) => `<a href="${pullRequest.html_url}">${pullRequest.title}</a>`).join('\n')}</body>`,
   })
 }


### PR DESCRIPTION
closes #265 

Issue was because of invalid tags <br/>. See https://developers.asana.com/docs/rich-text#reading-rich-text for a list of available html tags.